### PR TITLE
Fix #8: IKUpload should pick fileName by default if not provided explicitly

### DIFF
--- a/samples/sample-app/src/App.js
+++ b/samples/sample-app/src/App.js
@@ -55,7 +55,6 @@ function App() {
       <p>Upload</p>
       <IKContext publicKey={publicKey} urlEndpoint={urlEndpoint} authenticationEndpoint={authenticationEndpoint} >
         <IKUpload
-         fileName=""
          tags={["sample-tag1","sample-tag2"]}
          customCoordinates={"10,10,10,10"}
          isPrivateFile={false}

--- a/samples/sample-app/src/App.js
+++ b/samples/sample-app/src/App.js
@@ -55,7 +55,7 @@ function App() {
       <p>Upload</p>
       <IKContext publicKey={publicKey} urlEndpoint={urlEndpoint} authenticationEndpoint={authenticationEndpoint} >
         <IKUpload
-         fileName="sample-file.jpg"
+         fileName=""
          tags={["sample-tag1","sample-tag2"]}
          customCoordinates={"10,10,10,10"}
          isPrivateFile={false}

--- a/src/components/IKUpload/IKUpload.js
+++ b/src/components/IKUpload/IKUpload.js
@@ -9,8 +9,12 @@ export default class IKUpload extends ImageKitComponent {
       customOnChangeHandler(e);
       return;
     }
+    const file = e.target.files[0];
 
-    this.upload(e.target.files[0], fileName, useUniqueFileName, tags, folder, isPrivateFile, customCoordinates, responseFields, extendedProps, onError, onSuccess)
+    const customFileName = fileName.trim();
+    const uploadFileName = customFileName && customFileName.length ? customFileName : file.name;
+
+    this.upload(file, uploadFileName, useUniqueFileName, tags, folder, isPrivateFile, customCoordinates, responseFields, extendedProps, onError, onSuccess)
   }
 
   render() {

--- a/src/test/__snapshots__/storyshots.test.js.snap
+++ b/src/test/__snapshots__/storyshots.test.js.snap
@@ -22,6 +22,13 @@ exports[`Storyshots IKContext imagePublicKeyFail 1`] = `
 </h1>
 `;
 
+exports[`Storyshots IKUpload imageKitUploadWithoutFileName 1`] = `
+<input
+  onChange={[Function]}
+  type="file"
+/>
+`;
+
 exports[`Storyshots IKUpload imageKitUploadwithAllTheProps 1`] = `
 <input
   onChange={[Function]}

--- a/src/test/stories/3-ImageKitUpload.stories.js
+++ b/src/test/stories/3-ImageKitUpload.stories.js
@@ -30,6 +30,13 @@ storiesOf("IKUpload", module)
       </IKContext>
   )
   .add(
+    "imageKitUploadWithoutFileName",
+    () =>
+      <IKContext publicKey={publicKey} urlEndpoint={urlEndpoint} authenticationEndpoint={authenticationEndpoint} >
+        <IKUpload useUniqueFileName="true" onError={onError} onSuccess={onSuccess} />
+      </IKContext>
+  )
+  .add(
     "imageKitUploadwithoutAuthentication",
     () =>
       <IKContext publicKey={publicKey} urlEndpoint={urlEndpoint}>


### PR DESCRIPTION
**Fixes #8:**

If a  valid `fileName` isn't provided to `IKUpload` component, it will default to the name of the file that was selected for upload.

Changed `sample-app` to also not set the `fileName` explicitly during upload. 

Added a test case in storybook as well.