### PR TITLE
Add inputRef to allow access to element

### DIFF
--- a/src/components/IKUpload/index.js
+++ b/src/components/IKUpload/index.js
@@ -9,6 +9,11 @@ const PROP_TYPES = {
 };
 
 export default class IKUpload extends ImageKitComponent {
+  constructor(props, context) {
+    super(props, context)
+    this.inputRef = React.createRef();
+  }
+
   uploadFile(e) {
     const contextOptions = this.getContext();
 
@@ -106,6 +111,7 @@ export default class IKUpload extends ImageKitComponent {
     return (
       <input
         type="file"
+        ref={this.inputRef}
         {...restProps}
         onChange={(e) => {
           if (this.props.onChange && typeof this.props.onChange === "function") {

--- a/src/test/IKUpload.test.js
+++ b/src/test/IKUpload.test.js
@@ -205,6 +205,20 @@ describe('IKUpload', () => {
         // verify change callback
         expect(onChange.calledOnce).toEqual(true);
       });
+
+      test('should allow access to inputRef', () => {
+        const ikUploadRef = React.createRef();
+
+        // mount component
+        const ikUpload = mount(
+          <IKContext publicKey={publicKey} urlEndpoint={urlEndpoint} authenticationEndpoint={authenticationEndpoint} >
+            <IKUpload onError={onError} onSuccess={onSuccess} onChange={onChange} ref={ikUploadRef} />
+          </IKContext>
+        );
+        // verify setup integrity
+        expect(ikUpload.html()).toEqual('<input type="file">');        
+        expect(ikUploadRef.current.inputRef.current.tagName).toEqual('INPUT');
+      });
     });
   });
 


### PR DESCRIPTION
This adds an `inputRef` to allow a parent component to access the reference to the input dom node. This would be useful in the case where you make a custom-styled upload component, but want to rely on the behavior of this component.

Example:
```javascript
<button type="button" className="styled-button" onClick={() => ikUploadRef.current.inputRef.current.click()}>Upload File!</button>
<IKUpload ref={ikUploadRef} style={{display: 'none'}} />
```