### PR TITLE
IMAGEKIT-778: Fix React SDK CI pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:cov": "jest --coverage",
     "test:e2e": "cypress open",
     "test:watch": "jest --watch",
-    "serve:test-app": "export SKIP_PREFLIGHT_CHECK=true;npx serve -s tests/test-app/build -p 4000"
+    "serve:test-app": "export SKIP_PREFLIGHT_CHECK=true;npx serve@13.0.2 -s tests/test-app/build -p 4000"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes version of temporary npx module `serve` @ 13.0.2. 

This can later be improved by running the CI on Node v14 separately as well.